### PR TITLE
特定のNODE_ENVでタスクをスキップする関数を実装した

### DIFF
--- a/lib/define.js
+++ b/lib/define.js
@@ -71,6 +71,32 @@ Object.assign(define, {
   },
 
   /**
+   * Define task to skip when env matches
+   * @function skipFor
+   * @param {string} nodeEnv
+   * @param {function} task
+   * @returns {task}
+   */
+  skipFor (nodeEnv, task) {
+    const skip = () => {}
+    const wrapBySkipTask = (task) => (ctx) => {
+      const {NODE_ENV} = process.env
+      const hit = String(NODE_ENV).trim() === String(nodeEnv).trim()
+      if (hit) {
+        const {logger} = ctx
+        logger.debug(`Task "${task.name}" is skipped; for NODE_ENV = ${NODE_ENV}`)
+      } else {
+        return task(ctx)
+      }
+    }
+    const wrapped = wrapBySkipTask(task)
+    for (const sub of Object.keys(task)) {
+      wrapped[sub] = wrapBySkipTask(task[sub])
+    }
+    return wrapped
+  },
+
+  /**
    * Define dynamic tasks
    * @param {function} taskCreator = task creator function
    * @param {Object} [options={}] - Optional settings

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * Pon task to set NODE_ENV
  * @module pon-task-env
- * @version 1.3.2
+ * @version 1.3.3
  */
 
 'use strict'

--- a/test/define_test.js
+++ b/test/define_test.js
@@ -56,6 +56,22 @@ describe('define', function () {
     await task(ctx)
     await task.bar(ctx)
   })
+
+  it('Skip', async () => {
+    const ctx = ponContext()
+    const task = function task () { console.log('Do main task.') }
+    task.subTask = function subTask () { console.log('Do sub task.') }
+    const skipForTest = define.skipFor('test', task)
+
+    const {NODE_ENV} = process.env
+
+    process.env.NODE_ENV = 'test'
+
+    skipForTest(ctx)
+    skipForTest.subTask(ctx)
+
+    process.env.NODE_ENV = NODE_ENV
+  })
 })
 
 /* global describe, before, after, it */


### PR DESCRIPTION
`skipFor('production', someTask)` で、NODE_ENV=production のときに無視する。